### PR TITLE
fix for hardened images

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,11 +18,13 @@
   file:
     path: "{{ redis_install_dir }}"
     state: directory
+    mode: 0755
 
 - name: Create Redis folder in /etc
   file:
     path: "/etc/redis"
     state: directory
+    mode: 0755
 
 - name: Check if Redis user exists
   command: id {{ redis_user }}


### PR DESCRIPTION
When using hardened images, the directories are created using umask 0077 settings, so redis user won't be able to exec the redis binary or read the redis config file